### PR TITLE
Fixup the build system so clangd works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ mlx5ctl
 *.o
 .vscode
 *.code-workspace
+.cache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+project(mlx5ctl LANGUAGES C)
+cmake_minimum_required(VERSION 3.18.1 FATAL_ERROR)
+
+include(CheckCCompilerFlag)
+
+function(CTL_AddOptCFlag TO_VAR CACHE_VAR FLAG)
+  CHECK_C_COMPILER_FLAG("${FLAG}" ${CACHE_VAR})
+  if (${CACHE_VAR})
+    SET(${TO_VAR} "${${TO_VAR}} ${FLAG}" PARENT_SCOPE)
+  endif()
+endfunction()
+
+CTL_AddOptCFlag(CMAKE_C_FLAGS HAVE_C_WARNINGS
+  "-Wall -Wextra -Wno-sign-compare -Wno-unused-parameter")
+CTL_AddOptCFlag(CMAKE_C_FLAGS HAVE_C_WMISSING_PROTOTYPES "-Wmissing-prototypes")
+CTL_AddOptCFlag(CMAKE_C_FLAGS HAVE_C_WMISSING_DECLARATIONS "-Wmissing-declarations")
+CTL_AddOptCFlag(CMAKE_C_FLAGS HAVE_C_WWRITE_STRINGS "-Wwrite-strings")
+CTL_AddOptCFlag(CMAKE_C_FLAGS HAVE_C_WFORMAT_2 "-Wformat=2")
+CTL_AddOptCFlag(CMAKE_C_FLAGS HAVE_C_WCAST_FUNCTION "-Wcast-function-type")
+CTL_AddOptCFlag(CMAKE_C_FLAGS HAVE_C_WFORMAT_NONLITERAL "-Wformat-nonliteral")
+CTL_AddOptCFlag(CMAKE_C_FLAGS HAVE_C_WDATE_TIME "-Wdate-time")
+CTL_AddOptCFlag(CMAKE_C_FLAGS HAVE_C_WNESTED_EXTERNS "-Wnested-externs")
+
+add_executable(mlx5ctl
+  devcaps.c
+  diag_cnt.c
+  mlx5ctl_misc.c
+  mlx5ctlu.c
+  mlx5lib.c
+  query_obj.c
+  reg.c
+  rscdump.c
+)
+
+install(TARGETS mlx5ctl DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/Dockerfiles/fedora34.Dockerfile
+++ b/Dockerfiles/fedora34.Dockerfile
@@ -8,7 +8,7 @@ ARG APP_VERSION=1.0
 WORKDIR /mlx5ctl
 
 # Install necessary build tools and dependencies
-RUN dnf install -y rpm-build gcc make
+RUN dnf install -y rpm-build gcc make cmake git ninja-build
 
 # Copy your C application source code into the container
 COPY . .
@@ -27,8 +27,8 @@ RUN echo "Building version $APP_VERSION"
 # RUN chown -R user:user /app
 
 # Run the commands to build the RPM package
-RUN make VERSION=${APP_VERSION} srctar && mkdir -p /root/rpmbuild/SOURCES/ && \
-        mv SOURCE/mlx5ctl-${APP_VERSION}.tar.gz /root/rpmbuild/SOURCES/
+RUN mkdir -p /root/rpmbuild/SOURCES/ && \
+    git archive --prefix mlx5ctl-${APP_VERSION}/ --output /root/rpmbuild/SOURCES/mlx5ctl-${APP_VERSION}.tar.gz HEAD
 RUN ls -l /root/rpmbuild/SOURCES/
 RUN cd rpm && rpmbuild -bb --define "APP_VERSION ${APP_VERSION}" mlx5ctl.spec --define 'debug_package %{nil}'
 RUN mkdir /packages/ && \

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ dumps to be used in conjunction with other parsing tools such as
 ### Installation
 
 ```bash
+$ cmake .
 $ make
 $ sudo make install
 

--- a/devcaps.c
+++ b/devcaps.c
@@ -244,7 +244,7 @@ int do_devcap(struct mlx5u_dev *dev, int argc, char *argv[])
 				return 0;
 			}
 			fprintf(stderr, "No pretty print function for cap type %d\n", cap_type);
-			//fallthrough
+			fallthrough;
 		case PR_HEX:
 			hexdump(cap, MLX5_ST_SZ_BYTES(cmd_hca_cap));
 			break;

--- a/devcaps.c
+++ b/devcaps.c
@@ -192,7 +192,7 @@ static void parse_args(int argc, char *argv[])
 	}
 }
 
-void *query_caps(struct mlx5u_dev *dev, u16 opmod, void *out)
+static void *query_caps(struct mlx5u_dev *dev, u16 opmod, void *out)
 {
 	int out_sz = MLX5_ST_SZ_BYTES(query_hca_cap_out);
 	u8 in[MLX5_ST_SZ_BYTES(query_hca_cap_in)] = {};

--- a/devcaps.c
+++ b/devcaps.c
@@ -237,7 +237,7 @@ int do_devcap(struct mlx5u_dev *dev, int argc, char *argv[])
 
 		switch (pr_format)
 		{
-		case PR_PRETTY:
+		case PR_PRETTY: {
 			printcap_t print = get_cap_print(cap_type);
 			if (print) {
 				print(cap);
@@ -245,6 +245,7 @@ int do_devcap(struct mlx5u_dev *dev, int argc, char *argv[])
 			}
 			fprintf(stderr, "No pretty print function for cap type %d\n", cap_type);
 			fallthrough;
+		}
 		case PR_HEX:
 			hexdump(cap, MLX5_ST_SZ_BYTES(cmd_hca_cap));
 			break;

--- a/devcaps.c
+++ b/devcaps.c
@@ -6,7 +6,6 @@
 #include <errno.h>
 #include <string.h>
 #include <getopt.h>
-#include <ctype.h>
 
 #include "mlx5ctlu.h"
 #include "ifcutil.h"

--- a/devcaps.c
+++ b/devcaps.c
@@ -45,7 +45,7 @@ typedef void (*printcap_t)(void *out);
 
 struct cap_info {
 	enum mlx5_cap_type type;
-	char *name;
+	const char *name;
 	printcap_t print;
 };
 

--- a/ifcutil.h
+++ b/ifcutil.h
@@ -9,7 +9,7 @@
 
 #include <endian.h>
 #include <stdint.h>
-#include <stdlib.h>
+#include <stdio.h>
 
 typedef uint8_t u8;
 typedef uint16_t u16;

--- a/mlx5_ifc.h
+++ b/mlx5_ifc.h
@@ -2329,12 +2329,14 @@ struct mlx5_ifc_resource_dump_terminate_segment_bits {
 	struct mlx5_ifc_resource_dump_segment_header_bits segment_header;
 };
 
+/*
 struct mlx5_ifc_menu_resource_dump_response_bits {
 	struct mlx5_ifc_resource_dump_info_segment_bits info;
 	struct mlx5_ifc_resource_dump_command_segment_bits cmd;
 	struct mlx5_ifc_resource_dump_menu_segment_bits menu;
 	struct mlx5_ifc_resource_dump_terminate_segment_bits terminate;
 };
+*/
 
 union mlx5_ifc_resource_dump_segment_union_bits {
 	struct mlx5_ifc_resource_dump_resource_segment_bits resource;

--- a/mlx5_ifc.h
+++ b/mlx5_ifc.h
@@ -32,6 +32,8 @@
 #ifndef MLX5_IFC_H
 #define MLX5_IFC_H
 
+#include "ifcutil.h"
+
 enum {
 	MLX5_EVENT_TYPE_CODING_COMPLETION_EVENTS                   = 0x0,
 	MLX5_EVENT_TYPE_CODING_PATH_MIGRATED_SUCCEEDED             = 0x1,

--- a/mlx5ctl.h
+++ b/mlx5ctl.h
@@ -4,6 +4,8 @@
 #ifndef __MLX5CTL_IOCTL_H__
 #define __MLX5CTL_IOCTL_H__
 
+#include <linux/types.h>
+
 struct mlx5ctl_info {
 	__u16 uctx_uid; /* current process allocated UCTX UID */
 	__u16 reserved1; /* explicit padding must be zero */

--- a/mlx5ctl_misc.c
+++ b/mlx5ctl_misc.c
@@ -59,8 +59,8 @@ static char *find_parent_device(char *device_name, char parent_dev[DEV_NAME_MAX]
 static struct mlx5ctl_dev *_scan_ctl_devs(int *count) {
 	glob_t glob_result;
 	struct mlx5ctl_dev *devs;
-	char* pattern = "/dev/mlx5ctl*";
-	char parent_device_name[DEV_NAME_MAX];
+        const char *pattern = "/dev/mlx5ctl*";
+        char parent_device_name[DEV_NAME_MAX];
 	int ret = glob(pattern, GLOB_TILDE, NULL, &glob_result);
 
 	if(ret != 0) {

--- a/mlx5ctl_misc.c
+++ b/mlx5ctl_misc.c
@@ -40,7 +40,7 @@ static char *find_parent_device(char *device_name, char parent_dev[DEV_NAME_MAX]
 {
 	char resolved_path[PATH_MAX];
 	char dev_path[PATH_MAX];
-        char *parent, basename;
+        char *parent;
 
 	snprintf(dev_path, sizeof(dev_path),
 		 "/sys/bus/auxiliary/devices/%s", device_name);
@@ -242,9 +242,9 @@ int mlx5u_cmd(struct mlx5u_dev *dev, void *in, size_t inlen, void *out, size_t o
 	int fd = dev->fd;
 	int ret;
 
-	rpc.in = (__aligned_u64)in;
+	rpc.in = (__u64)in;
 	rpc.inlen = inlen;
-	rpc.out = (__aligned_u64)out;
+	rpc.out = (__u64)out;
 	rpc.outlen = outlen;
 
 	ret = ioctl(fd, MLX5CTL_IOCTL_CMDRPC, &rpc);

--- a/mlx5ctlu.c
+++ b/mlx5ctlu.c
@@ -16,16 +16,11 @@
 // Define the global verbosity level
 int verbosity_level = 0;
 
-int do_help(struct mlx5u_dev *dev, int argc, char *argv[]);
-int do_devinfo(struct mlx5u_dev *dev, int argc, char *argv[]);
-int do_devcap(struct mlx5u_dev *dev, int argc, char *argv[]);
-int do_reg(struct mlx5u_dev *dev, int argc, char *argv[]);
-int query_obj(struct mlx5u_dev *dev, int argc, char *argv[]);
-int do_diag_cnt(struct mlx5u_dev *dev, int argc, char *argv[]);
-int do_rscdump(struct mlx5u_dev *dev, int argc, char *argv[]);
-int do_sleep(struct mlx5u_dev *dev, int argc, char *argv[]);
-
 static char *help_cmd;
+
+static int do_help(struct mlx5u_dev *dev, int argc, char *argv[]);
+static int do_devinfo(struct mlx5u_dev *dev, int argc, char *argv[]);
+static int do_sleep(struct mlx5u_dev *dev, int argc, char *argv[]);
 
 static const cmd commands[] = {
 	{ "info", do_devinfo,  "Print device information" }, // Default
@@ -55,7 +50,7 @@ int cmd_select(struct mlx5u_dev *dev, const cmd *cmds, int argc, char **argv)
 	return -1;
 }
 
-int do_help(struct mlx5u_dev *dev, int argc, char *argv[])
+static int do_help(struct mlx5u_dev *dev, int argc, char *argv[])
 {
 	fprintf(stdout, "Usage: %s <mlx5 pci device> <command> [options]\n", help_cmd);
 	fprintf(stdout, "Verbosity: %s -v <mlx5 pci device> <command> [options]\n", help_cmd);
@@ -66,12 +61,12 @@ int do_help(struct mlx5u_dev *dev, int argc, char *argv[])
 	return 0;;
 }
 
-int do_devinfo(struct mlx5u_dev *dev, int argc, char *argv[])
+static int do_devinfo(struct mlx5u_dev *dev, int argc, char *argv[])
 {
 	return mlx5u_devinfo(dev);
 }
 
-int do_sleep(struct mlx5u_dev *dev, int argc, char *argv[])
+static int do_sleep(struct mlx5u_dev *dev, int argc, char *argv[])
 {
 	int sleep_time;
 

--- a/mlx5ctlu.h
+++ b/mlx5ctlu.h
@@ -21,6 +21,12 @@ extern int verbosity_level;
 		} \
 	} while (0)
 
+#if __GNUC__ >= 7
+#define fallthrough __attribute__ ((fallthrough))
+#else
+#define fallthrough
+#endif
+
 struct mlx5u_dev;
 typedef struct cmd {
 	const char *name;

--- a/mlx5ctlu.h
+++ b/mlx5ctlu.h
@@ -38,4 +38,10 @@ int mlx5u_umem_reg(struct mlx5u_dev *dev, void *addr, size_t len);
 int mlx5u_umem_unreg(struct mlx5u_dev *dev, __uint32_t umem_id);
 int cmd_select(struct mlx5u_dev *dev, const cmd *cmds, int argc, char **argv);
 
+int do_devcap(struct mlx5u_dev *dev, int argc, char *argv[]);
+int do_reg(struct mlx5u_dev *dev, int argc, char *argv[]);
+int query_obj(struct mlx5u_dev *dev, int argc, char *argv[]);
+int do_diag_cnt(struct mlx5u_dev *dev, int argc, char *argv[]);
+int do_rscdump(struct mlx5u_dev *dev, int argc, char *argv[]);
+
 #endif /* __MLX5CTL_H__ */

--- a/mlx5ctlu.h
+++ b/mlx5ctlu.h
@@ -4,7 +4,7 @@
 #ifndef __MLX5CTL_H__
 #define __MLX5CTL_H__
 
-#include "ifcutil.h"
+#include <stdlib.h>
 
 #define err_msg(fmt, ...) \
 	fprintf(stderr, "Error : " fmt, ##__VA_ARGS__)

--- a/query_obj.c
+++ b/query_obj.c
@@ -55,8 +55,6 @@ static void parse_args(int argc, char *argv[])
 			break;
 		case 'o':
 			op_mod = strtoul(optarg, NULL, 0);
-			/* when op_mod is specified, obj_id becomes optional */
-			obj_id = obj_id < 0 ? 0 : obj_id;
 			break;
 		case 'B':
 			bin_format = 1;

--- a/query_obj.c
+++ b/query_obj.c
@@ -19,7 +19,7 @@ static unsigned	int bin_format = 0;
 
 static void print_query_funcs(void);
 
-void help(void)
+static void help(void)
 {
 	fprintf(stdout, "Usage: mlx5ctl <device> obj <obj_name> --id=<obj_id> [--op_mod=op_mod] [--bin]\n");
 	fprintf(stdout, "executes PRM command query_<obj_name>_in\n");

--- a/query_obj.c
+++ b/query_obj.c
@@ -392,9 +392,9 @@ QUERY_FUNC(sf_partitions)
 
 
 struct obj_name_func {
-	char *obj_name;
+	const char *obj_name;
 	query_obj_func obj_func;
-	char *help;
+	const char *help;
 };
 
 #define QUERY_PAIR(name, help) {#name, query_##name, help}

--- a/reg.c
+++ b/reg.c
@@ -320,6 +320,7 @@ static int mlx5_reg_dump(struct mlx5u_dev *dev, u32 reg_id, u32 port, u32 argume
 			break;
 		}
 		err_msg("No pretty print function for register %s 0x%x\n", reg2str(reg_id), reg_id);
+		fallthrough;
 	case PR_HEX:
 		hexdump(out, reg_size);
 		break;

--- a/reg.c
+++ b/reg.c
@@ -22,7 +22,7 @@ typedef void (*reg_pretty_print)(void* data);
 
 struct reg_info {
 	u32 reg_id;
-	char *str;
+	const char *str;
 	u32 size;
 	reg_pretty_print ppfun;
 };

--- a/reg.c
+++ b/reg.c
@@ -123,7 +123,7 @@ static const char* reg2str(u32 reg_id)
 	return "UNKNOWN_REG_STR";
 }
 
-static const unsigned int get_reg_size(u32 reg_id)
+static unsigned int get_reg_size(u32 reg_id)
 {
 	for (int i = 0; i < sizeof(regs) / sizeof(struct reg_info); i++) {
 		if (regs[i].reg_id == reg_id)

--- a/rpm/mlx5ctl.spec
+++ b/rpm/mlx5ctl.spec
@@ -7,19 +7,57 @@ Group: Development/Tools
 URL: https://github.com/saeedtx/mlx5ctl
 Source0: mlx5ctl-%{APP_VERSION}.tar.gz
 
+BuildRequires: binutils
+BuildRequires: cmake >= 3.18
+
+# Ninja was introduced in FC23
+BuildRequires: ninja-build
+%define CMAKE_FLAGS -GNinja
+%if 0%{?fedora} >= 33 || 0%{?rhel} >= 9
+%define make_jobs ninja-build -C %{_vpath_builddir} -v %{?_smp_mflags}
+%define cmake_install DESTDIR=%{buildroot} ninja-build -C %{_vpath_builddir} install
+%else
+%define make_jobs ninja-build -v %{?_smp_mflags}
+%define cmake_install DESTDIR=%{buildroot} ninja-build install
+%endif
+
 %description
 Userspace Linux Debug Utilities for mlx5 ConnectX Devices
-
-%define _bindir /usr/local/bin
 
 %prep
 %setup -q
 
 %build
-make
+
+# New RPM defines _rundir, usually as /run
+%if 0%{?_rundir:1}
+%else
+%define _rundir /var/run
+%endif
+
+# Pass all of the rpm paths directly to GNUInstallDirs and our other defines.
+%cmake %{CMAKE_FLAGS} \
+         -DCMAKE_BUILD_TYPE=Release \
+         -DCMAKE_INSTALL_BINDIR:PATH=%{_bindir} \
+         -DCMAKE_INSTALL_SBINDIR:PATH=%{_sbindir} \
+         -DCMAKE_INSTALL_LIBDIR:PATH=%{_lib} \
+         -DCMAKE_INSTALL_LIBEXECDIR:PATH=%{_libexecdir} \
+         -DCMAKE_INSTALL_LOCALSTATEDIR:PATH=%{_localstatedir} \
+         -DCMAKE_INSTALL_SHAREDSTATEDIR:PATH=%{_sharedstatedir} \
+         -DCMAKE_INSTALL_INCLUDEDIR:PATH=include \
+         -DCMAKE_INSTALL_INFODIR:PATH=%{_infodir} \
+         -DCMAKE_INSTALL_MANDIR:PATH=%{_mandir} \
+         -DCMAKE_INSTALL_SYSCONFDIR:PATH=%{_sysconfdir} \
+         -DCMAKE_INSTALL_SYSTEMD_SERVICEDIR:PATH=%{_unitdir} \
+         -DCMAKE_INSTALL_INITDDIR:PATH=%{_initrddir} \
+         -DCMAKE_INSTALL_RUNDIR:PATH=%{_rundir} \
+         -DCMAKE_INSTALL_DOCDIR:PATH=%{_docdir}/%{name} \
+         -DCMAKE_INSTALL_UDEV_RULESDIR:PATH=%{_udevrulesdir} \
+         -DCMAKE_INSTALL_PERLDIR:PATH=%{perl_vendorlib}
+%make_jobs
 
 %install
-make install DESTDIR=%{buildroot}
+%cmake_install
 
 %files
 %{_bindir}/mlx5ctl

--- a/rscdump.c
+++ b/rscdump.c
@@ -503,10 +503,6 @@ int do_rscdump(struct mlx5u_dev *dev, int argc, char *argv[])
 		size_t umem_buff_size = args.umem * 1024;
 		int err;
 
-		if (umem_buff_size < 0) {
-			err_msg("Invalid data size %zu\n", umem_buff_size);
-			return -EINVAL;
-		}
 		err = mlx5lib_alloc_pd(dev, &umem_pdn, 0);
 		if (err)
 			return err;

--- a/rscdump.c
+++ b/rscdump.c
@@ -236,7 +236,7 @@ static int mlx5_rsc_sgmt_type_by_name(char *name)
 	return -1; /* Not implemented */
 }
 
-void print_menu_record(void *record)
+static void print_menu_record(void *record)
 {
 	int seg_type = MLX5_GET(resource_dump_menu_record, record, segment_type);
 
@@ -451,7 +451,7 @@ static int parse_rsc_dump_type_arg(char *arg)
 static const char *usage = "[--umem=<size KB>] [--type=<type>] [--idx1=<index1>] [--idx2=<index2>] [--vhcaid=<vhca_id>] [--help]";
 static const char *usage_core_dump = "[--umem=<size KB>] [--help]";
 
-Args parse_args(int argc, char *argv[])
+static Args parse_args(int argc, char *argv[])
 {
 	Args args = {0};
 	const char *usage_str;

--- a/rscdump.c
+++ b/rscdump.c
@@ -448,13 +448,13 @@ static int parse_rsc_dump_type_arg(char *arg)
 	return 0;
 }
 
-static char *usage = "[--umem=<size KB>] [--type=<type>] [--idx1=<index1>] [--idx2=<index2>] [--vhcaid=<vhca_id>] [--help]";
-static char *usage_core_dump = "[--umem=<size KB>] [--help]";
+static const char *usage = "[--umem=<size KB>] [--type=<type>] [--idx1=<index1>] [--idx2=<index2>] [--vhcaid=<vhca_id>] [--help]";
+static const char *usage_core_dump = "[--umem=<size KB>] [--help]";
 
 Args parse_args(int argc, char *argv[])
 {
 	Args args = {0};
-	char *usage_str;
+	const char *usage_str;
 	args.type = -1;
 
 	if (strcmp(argv[0], "coredump") == 0)


### PR DESCRIPTION
Move it to  small chunk of cmake so we can trivially get a compile compile_commands.json. This also makes header file build dependencies work.

Fix a whole wack of compiler warnings from enabling more flags and building with clang and gcc

Fixup the RPM build spec file

clangd works in vscode now.

```
    $ cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -GNinja
    $ ninja
```